### PR TITLE
Deleted CNAME to fix docs redirect

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-chassis.ml

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-chassis.ml

--- a/docs/docs/CNAME
+++ b/docs/docs/CNAME
@@ -1,1 +1,0 @@
-chassis.ml


### PR DESCRIPTION
Deleted all instances of CNAME in repo to resolve issue of docs domain resetting to chassis.ml everytime there's a push to main